### PR TITLE
Mitigated perms issues in build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,11 +53,23 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v2
     - name: Delete tag and release
-      run: gh release delete bleeding-edge -y
+      uses: dev-drprasad/delete-tag-and-release@v1.0
+      with:
+        delete_release: true # default: false
+        tag_name: bleeding-edge # tag name to delete
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Release
-      run: gh release create bleeding-edge */* --notes "Automatically generated bleeding edge release"
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: bleeding-edge
+        name: Bleeding Edge
+        prerelease: false
+        fail_on_unmatched_files: true
+        files: |
+          */*
+        body: | 
+          Automatically generated bleeding edge release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,6 @@
 name: Build
 
 on:
-  workflow_run:
-    branches: ['main']
-    workflows: ['Test']
-    types: ['completed']
   workflow_dispatch:
     
 


### PR DESCRIPTION
Previously build action would run on every commit to main, which due to disorganised nature of repository management could happen very often. This would result in attempts of unauthorized access to releases page. This shouldn't happen anymore.